### PR TITLE
ci: fix broken build due to modified hugo deb URL

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Install Hugo CLI
         run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.deb \
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Upgrade to a newer HUGO version they changed the URL of the amd64 binary which broke our build. Really should add this check in pre-merge, but for now need to resolve.

<img width="1293" alt="image" src="https://user-images.githubusercontent.com/10994715/204168729-0a85434d-c335-4ed1-bced-21de3638c7bb.png">
