### PR TITLE
ci: remove beautifulhugo git submodule

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -37,8 +37,6 @@ jobs:
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          submodules: recursive
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "themes/beautifulhugo"]
-	path = themes/beautifulhugo
-	url = https://github.com/f3peakcity/beautifulhugo.git


### PR DESCRIPTION
Instead hugo automagically pulls the dependency from the go.mod file so there is no need to have the submodule any longer. Additionally this is causing a build break.

<img width="1044" alt="image" src="https://user-images.githubusercontent.com/10994715/204170272-36d1ca3e-785a-45cd-adfb-cb0cc085f74a.png">
