### PR TITLE
fix: switch to using hugo default titles

### DIFF
--- a/content/contact/index.md
+++ b/content/contact/index.md
@@ -1,4 +1,8 @@
-# Contact
+---
+title: CONTACT
+comments: false
+socialShare: false
+---
 
 If you're on [Slack](/slack), you can directly message one of the [Leadership](/leadership) team.
 
@@ -6,4 +10,6 @@ For website comments, see [GitHub](https://github.com/f3peakcity/f3peakcity.gith
 
 If you're new to F3, visiting from out of town, or just have a general question or comment, please fill out the following form.
 
-<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSfE9sQy379OL3wxsoxUy_yNRmRv2g1psGgP0y0UwNCirBcY4w/viewform?embedded=true" width="640" height="752" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+<div align="center">
+  <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSfE9sQy379OL3wxsoxUy_yNRmRv2g1psGgP0y0UwNCirBcY4w/viewform?embedded=true" width="100%" height="752" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+</div>

--- a/content/new-to-f3/index.md
+++ b/content/new-to-f3/index.md
@@ -1,4 +1,7 @@
-# New to F3?
+---
+title: NEW TO F3?
+comments: false
+---
 
 Everyone starts off as a "friendly new guy" (FNG) and then gets a slightly silly nickname after completing a workout.
 

--- a/content/slack/index.md
+++ b/content/slack/index.md
@@ -1,4 +1,8 @@
-# Slack
+---
+title: SLACK
+comments: false
+socialShare: false
+---
 
 {{< columns >}}
 Slack is a group chat app that serves as our group's virtual space for all sorts of mumblechatter. You can access Slack from your phone, desktop, or browser.


### PR DESCRIPTION
- fix the contact form width to vary based on the
    width of the browser
    
- align the the contact form in the center of the page
    
- fix titles to use the larger standard font from the hugo
    theme

Resolves issue #8 

@ugotmarcus this should resolve [your comment ](https://github.com/f3peakcity/f3peakcity.github.io/issues/8#issuecomment-1356319705)

New Contact Page

<img width="886" alt="image" src="https://user-images.githubusercontent.com/10994715/209480114-7789c423-5cae-4582-9640-1eccd70bb125.png">

New Slack Header

<img width="829" alt="image" src="https://user-images.githubusercontent.com/10994715/209480125-ca6db376-3564-4162-9683-b67ca474fc30.png">
