### PR TITLE
feat: stats dashboard polish (May)

### DIFF
--- a/static/stats/ao.html
+++ b/static/stats/ao.html
@@ -22,7 +22,7 @@
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-menu" aria-controls="navbar-menu" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
-      <a href="index.html" class="navbar-brand">Peak City Stats</a>
+      <a href="https://f3peakcity.com" class="navbar-f3-logo" target="_blank" rel="noopener" aria-label="F3 Peak City"><img src="../img/brand/f3-peak-city-white-on-transparent.png" alt="F3 Peak City" height="26"></a><a href="index.html" class="navbar-brand">Peak City Stats</a>
       <div class="collapse navbar-collapse" id="navbar-menu">
         <ul class="navbar-nav">
           <li class="nav-item"><a class="nav-link active" href="ao.html">AO Stats</a></li>

--- a/static/stats/assets/css/custom.css
+++ b/static/stats/assets/css/custom.css
@@ -80,6 +80,17 @@ body,
 .navbar-toggler-icon {
   filter: invert(1);
 }
+.navbar-f3-logo {
+  display: flex;
+  align-items: center;
+  margin-right: 0.75rem;
+  padding-right: 0.75rem;
+  border-right: 1px solid rgba(255,255,255,0.15);
+  opacity: 0.9;
+  transition: opacity 0.15s;
+}
+.navbar-f3-logo:hover { opacity: 1; }
+.navbar-f3-logo img { height: 26px; width: auto; display: block; }
 
 /* ── Cards ── */
 .card {
@@ -566,6 +577,15 @@ th[data-sort].desc::after { content: ' ↓'; opacity: 1; color: var(--green); }
 .lb-status-track  { background: transparent; color: var(--green); border: 1.5px solid var(--green); }
 .lb-status-behind { background: #c8a840; color: var(--ink); }
 .lb-status-ghost  { background: transparent; color: var(--rule); border: 1.5px solid var(--rule); }
+
+/* ── AO Core PAX list ── */
+.ao-core-list {
+  font-family: 'Open Sans', sans-serif;
+  font-size: 0.72rem;
+  color: var(--text);
+  line-height: 1.5;
+  margin-top: 2px;
+}
 
 /* ── Top Q Leaders ranked list ── */
 #chart-qp-ratio {

--- a/static/stats/assets/js/ao.js
+++ b/static/stats/assets/js/ao.js
@@ -1,19 +1,36 @@
 // AO Stats page logic
 // Source: AO Stats tab, header at row index 2
 // Key columns: Site, Total Attendees, Avg/Meeting, FNGs, Unique Qs,
-//   Bench Strength, Active Core PAX, Most Frequent Q, Core Names, Weeks in Range
+//   Bench Strength, Active Core PAX, Most Frequent Q, Weeks in Range
+// Core PAX: cross-referenced from PAX tab via Favorite AO column
 
 (async function () {
   let allRows = [];
   let filteredRows = [];
+  let coreByAO = {};   // { aoSiteName: ['PAX1', 'PAX2', ...] }
   let attendanceChart = null;
   let fngsByAoChart = null;
 
   try {
-    const csv = await f3FetchCSV('ao');
-    allRows = f3ParseCSV(csv, 2);
-    // Remove rows where Site is blank (trailing sheet rows)
+    const [aoCsv, paxCsv] = await Promise.all([
+      f3FetchCSV('ao'),
+      f3FetchCSV('pax'),
+    ]);
+
+    allRows = f3ParseCSV(aoCsv, 2);
     allRows = allRows.filter(r => r['Site'] && r['Site'].trim() !== '');
+
+    // Build core PAX map: group PAX by their Favorite AO
+    const paxRows = f3ParseCSV(paxCsv, 2).filter(r => {
+      const s = (r['Site'] || '').trim();
+      return s !== '' && isNaN(Number(s));
+    });
+    paxRows.forEach(r => {
+      const ao = (r['Favorite AO'] || '').trim();
+      if (!ao || ao === '#downrange') return;
+      if (!coreByAO[ao]) coreByAO[ao] = [];
+      coreByAO[ao].push(r['Site'].trim());
+    });
   } catch (e) {
     f3ShowError('ao-table-container', e.message);
     f3ShowError('ao-cards-grid', e.message);
@@ -101,8 +118,11 @@
       const avg = parseFloat(r['Avg/Meeting']) || 0;
       const bench = parseFloat(r['Bench Strength']);
       const benchDisplay = isNaN(bench) ? (r['Bench Strength'] || '—') : bench.toFixed(1) + '%';
-      const cores = r['Core Names'] && r['Core Names'] !== '-' ? r['Core Names'] : 'None listed';
       const topQ = r['Most Frequent Q'] || '—';
+      const corePax = coreByAO[r['Site'].trim()] || [];
+      const coreHtml = corePax.length
+        ? corePax.map(name => f3Esc(name)).join(', ')
+        : '<em style="color:var(--muted);">None listed</em>';
       return `
         <div class="card card-stat-accent">
           <div class="card-header">
@@ -127,8 +147,8 @@
                 <div class="fw-bold">${f3Esc(topQ)}</div>
               </div>
             </div>
-            <div class="text-muted small mb-1">Core PAX (Regulars)</div>
-            <div class="small">${f3Esc(cores)}</div>
+            <div class="text-muted small mb-1">Core PAX (${corePax.length})</div>
+            <div class="ao-core-list">${coreHtml}</div>
           </div>
         </div>`;
     }).join('');

--- a/static/stats/assets/js/leaderboard.js
+++ b/static/stats/assets/js/leaderboard.js
@@ -42,8 +42,11 @@ const POST_GOAL = 12;
   }
 
   // Months with any data in the sheet totals; currentMonth = most recent non-zero
-  activeMonths = MONTHS.filter(m => sheetTotals[m] > 0);
-  currentMonth = activeMonths.length ? activeMonths[activeMonths.length - 1] : MONTHS[0];
+  // Current month from today's date — MONTHS is ordered Jan–Dec so getMonth() maps directly
+  const todayMonthIdx = new Date().getMonth(); // 0=Jan … 11=Dec
+  currentMonth = MONTHS[todayMonthIdx] ?? MONTHS[0];
+  // Active months = Jan through current month (whether or not completions exist yet)
+  activeMonths = MONTHS.filter((_, i) => i <= todayMonthIdx);
 
   // Default: PC Regulars only
   filteredRows = allRows.filter(r => (r['PC Reg.'] || '').trim().toUpperCase() === 'TRUE');

--- a/static/stats/assets/js/pax.js
+++ b/static/stats/assets/js/pax.js
@@ -159,9 +159,9 @@
   function renderTrajectoryChart(rows) {
     // Actual sheet values: '🔥 Heating Up', '❄️ Cooling Off', '-' (no change)
     const TRAJ_MAP = {
-      '🔥 Heating Up':  { label: 'Heating Up',  color: '#c8a840' },
-      '❄️ Cooling Off': { label: 'Cooling Off',  color: '#8a9aaf' },
-      '-':              { label: 'Steady',        color: '#c8bfa8' },
+      '🔥 Heating Up':  { label: '🔥 Heating Up',     color: '#c8a840' },
+      '❄️ Cooling Off': { label: '❄️ Cooling Off',    color: '#8a9aaf' },
+      '-':              { label: '➡️ Holding Steady',  color: '#c8bfa8' },
     };
     const counts = {};
     rows.forEach(r => {

--- a/static/stats/fng.html
+++ b/static/stats/fng.html
@@ -22,7 +22,7 @@
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-menu" aria-controls="navbar-menu" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
-      <a href="index.html" class="navbar-brand">Peak City Stats</a>
+      <a href="https://f3peakcity.com" class="navbar-f3-logo" target="_blank" rel="noopener" aria-label="F3 Peak City"><img src="../img/brand/f3-peak-city-white-on-transparent.png" alt="F3 Peak City" height="26"></a><a href="index.html" class="navbar-brand">Peak City Stats</a>
       <div class="collapse navbar-collapse" id="navbar-menu">
         <ul class="navbar-nav">
           <li class="nav-item"><a class="nav-link" href="ao.html">AO Stats</a></li>

--- a/static/stats/index.html
+++ b/static/stats/index.html
@@ -22,7 +22,7 @@
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-menu" aria-controls="navbar-menu" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
-      <a href="index.html" class="navbar-brand">Peak City Stats</a>
+      <a href="https://f3peakcity.com" class="navbar-f3-logo" target="_blank" rel="noopener" aria-label="F3 Peak City"><img src="../img/brand/f3-peak-city-white-on-transparent.png" alt="F3 Peak City" height="26"></a><a href="index.html" class="navbar-brand">Peak City Stats</a>
       <div class="collapse navbar-collapse" id="navbar-menu">
         <ul class="navbar-nav">
           <li class="nav-item"><a class="nav-link" href="ao.html">AO Stats</a></li>

--- a/static/stats/leaderboard.html
+++ b/static/stats/leaderboard.html
@@ -22,7 +22,7 @@
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-menu" aria-controls="navbar-menu" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
-      <a href="index.html" class="navbar-brand">Peak City Stats</a>
+      <a href="https://f3peakcity.com" class="navbar-f3-logo" target="_blank" rel="noopener" aria-label="F3 Peak City"><img src="../img/brand/f3-peak-city-white-on-transparent.png" alt="F3 Peak City" height="26"></a><a href="index.html" class="navbar-brand">Peak City Stats</a>
       <div class="collapse navbar-collapse" id="navbar-menu">
         <ul class="navbar-nav">
           <li class="nav-item"><a class="nav-link" href="ao.html">AO Stats</a></li>
@@ -92,6 +92,7 @@
         <span class="flag-text">Who's In The Crew</span>
         <span class="flag-rule"></span>
       </div>
+      <p style="font-family:'Open Sans',sans-serif;font-size:0.6rem;color:var(--muted);font-style:italic;margin:0.4rem 0 0.5rem;">* Current month post count only appears once you've completed a Q that month.</p>
       <div id="leaderboard-heatmap">
         <div class="d-flex justify-content-center p-4">
           <div class="spinner-border" role="status">

--- a/static/stats/pax.html
+++ b/static/stats/pax.html
@@ -22,7 +22,7 @@
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-menu" aria-controls="navbar-menu" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
-      <a href="index.html" class="navbar-brand">Peak City Stats</a>
+      <a href="https://f3peakcity.com" class="navbar-f3-logo" target="_blank" rel="noopener" aria-label="F3 Peak City"><img src="../img/brand/f3-peak-city-white-on-transparent.png" alt="F3 Peak City" height="26"></a><a href="index.html" class="navbar-brand">Peak City Stats</a>
       <div class="collapse navbar-collapse" id="navbar-menu">
         <ul class="navbar-nav">
           <li class="nav-item"><a class="nav-link" href="ao.html">AO Stats</a></li>


### PR DESCRIPTION
## Summary

- **AO Stats**: Each AO card now shows a Core PAX list, cross-referenced from the PAX tab's `Favorite AO` column — comma-separated, no longer relies on missing `Core Names` column
- **All pages**: F3 Peak City logo added to navbar, links to f3peakcity.com, uses `f3-peak-city-white-on-transparent.png` brand asset
- **PAX Stats**: Trajectory donut chart labels restored with emoji — `🔥 Heating Up`, `❄️ Cooling Off`, `➡️ Holding Steady`
- **Leaderboard**: Current month now driven by `new Date().getMonth()` instead of last non-zero completion month — fixes April being shown as current during May
- **Leaderboard**: Asterisk note above PAX habit grid explaining Q requirement for current month post count to appear

## Test plan

- [ ] `/stats/ao.html` — AO cards show "Core PAX (N)" with comma-separated names
- [ ] All 5 pages — F3 logo appears left of "Peak City Stats" in navbar, clicking opens f3peakcity.com in new tab
- [ ] `/stats/pax.html` — Trajectory donut shows emoji labels in legend
- [ ] `/stats/leaderboard.html` — Page header shows current month as May (not April); asterisk note visible above PAX grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)