### PR TITLE
chore: remove 100 Bag Challenge feature, fix external nav links

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -3,29 +3,6 @@
 
 {{< columns >}}
 
-<a href="articles/100-bag-challenge" target="_blank">
-  <img src="https://neighborup.org/wp-content/uploads/neighburuplogo.png" alt="NeighborUp" width="auto">
-
-#### **Peak City 100 Bag Challenge**
-</a>
-
-_Supporting the Peak City community in partnership with [NeighborUp](https://neighborup.org)_
-
-From Sugar to Shampoo: The 🎒 100 Bag Challenge Kicks Off a Sustained Giving Campaign—Grab a Bag and Make an Impact!
-
-{{< column >}}
-
-<picture>
-  <source srcset="/img/brand/f3-peak-city-white-on-transparent.png" media="(prefers-color-scheme:dark)">
-  <img height="320px" src="/img/brand/f3-peak-city-black-on-transparent.png">
-</picture>
-
-{{< endcolumns >}}
-
----
-
-{{< columns >}}
-
 ## Always Free.</br>Always Outside.</br>Open to All Men.
 
 Join us for 20+ free workouts right here in the "Peak of Good Living" in Apex, NC and the surrounding areas of Friendship, New Hill, and Jordan Lake.

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,0 +1,101 @@
+<nav class="navbar navbar-default navbar-fixed-top navbar-custom">
+  <div class="container-fluid">
+    <div class="navbar-header">
+      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#main-navbar">
+        <span class="sr-only">{{ i18n "toggleNavigation" }}</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <a class="navbar-brand" href="{{ "" | absLangURL }}">{{ .Site.Title }}</a>
+    </div>
+
+    <div class="collapse navbar-collapse" id="main-navbar">
+      <ul class="nav navbar-nav navbar-right">
+        {{ range .Site.Menus.main.ByWeight }}
+          {{ if .HasChildren }}
+            <li class="navlinks-container">
+              <a class="navlinks-parent">{{ .Name }}</a>
+              <div class="navlinks-children">
+                {{ range .Children }}
+                  <a href="{{ .URL | relLangURL }}"{{ if strings.HasPrefix .URL "http" }} target="_blank" rel="noopener"{{ end }}>{{ .Name }}</a>
+                {{ end }}
+              </div>
+            </li>
+          {{ else }}
+            <li>
+              <a title="{{ .Name }}" href="{{ .URL | relLangURL }}"{{ if strings.HasPrefix .URL "http" }} target="_blank" rel="noopener"{{ end }}>{{ .Name }}</a>
+            </li>
+          {{ end }}
+        {{ end }}
+
+        {{ if .Site.IsMultiLingual }}
+          {{ if ge (len .Site.Languages) 3 }}
+            <li class="navlinks-container">
+              <a class="navlinks-parent">{{ i18n "languageSwitcherLabel" }}</a>
+              <div class="navlinks-children">
+                {{ range .Site.Languages }}
+                  {{ if not (eq .Lang $.Site.Language.Lang) }}
+                  <a href="/{{ .Lang }}" lang="{{ .Lang }}">{{ default .Lang .LanguageName }}</a>
+                  {{ end }}
+                {{ end }}
+              </div>
+            </li>
+          {{ else }}
+            <li>
+              {{ range .Site.Languages }}
+                {{ if not (eq .Lang $.Site.Language.Lang) }}
+                  <a href="/{{ .Lang }}" lang="{{ .Lang }}">{{ default .Lang .LanguageName }}</a>
+                {{ end }}
+              {{ end }}
+            </li>
+          {{ end }}
+        {{ end }}
+
+        {{ if isset .Site.Params "gcse" }}
+          <li>
+            <a href="#modalSearch" data-toggle="modal" data-target="#modalSearch" style="outline: none;">
+              <span class="hidden-sm hidden-md hidden-lg">{{ i18n "gcseLabelShort" }}</span> <span id="searchGlyph" class="glyphicon glyphicon-search"></span>
+            </a>
+          </li>
+        {{ end }}
+      </ul>
+    </div>
+
+    {{ if isset .Site.Params "logo" }}
+      <div class="avatar-container">
+        <div class="avatar-img-border">
+          <a title="{{ .Site.Title }}" href="{{ "" | absLangURL }}">
+            <picture>
+              {{- with .Site.Params.darkLogo | default .Site.Params.logo }}
+              <source srcset="{{ . | absURL }}" media="(prefers-color-scheme:dark)">
+              {{- end }}
+              <img class="avatar-img" src="{{ .Site.Params.logo | absURL }}" alt="{{ .Site.Title }}">
+            </picture>
+          </a>
+        </div>
+      </div>
+    {{ end }}
+
+  </div>
+</nav>
+
+<!-- Search Modal -->
+{{ if isset .Site.Params "gcse" }}
+  <div id="modalSearch" class="modal fade" role="dialog">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal">&times;</button>
+          <h4 class="modal-title">{{ i18n "gcseLabelLong" . }}</h4>
+        </div>
+        <div class="modal-body">
+          <gcse:search></gcse:search>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal">{{ i18n "gcseClose" }}</button>
+        </div>
+      </div>
+    </div>
+  </div>
+{{ end }}


### PR DESCRIPTION
## Summary
- Removes the NeighborUp 100 Bag Challenge columns block from the homepage (`_index.md`)
- Adds a local `nav.html` partial override so any `http` menu link (e.g. Region Stats) opens in a new tab with `target="_blank" rel="noopener"`

## Test plan
- [ ] Homepage no longer shows the 100 Bag Challenge section
- [ ] "Region stats" link in PAX dropdown opens pax-vault.f3nation.com in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)