### PR TITLE
feat: migrate all stats pages to raw tab + leaderboard polish

### DIFF
--- a/static/stats/ao.html
+++ b/static/stats/ao.html
@@ -43,7 +43,7 @@
         <div class="row align-items-center">
           <div class="col">
             <h2 class="page-title">AO Stats</h2>
-            <p class="text-muted">Site health metrics for Site Qs</p>
+            <p class="text-muted">Site health metrics for Site Qs &mdash; all data from Jan 1, 2026</p>
           </div>
         </div>
       </div>

--- a/static/stats/ao.html
+++ b/static/stats/ao.html
@@ -9,6 +9,7 @@
   <noscript><link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@700;800;900&family=Lora:wght@400;600;700&family=Open+Sans:wght@400;500;600;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.0.0-beta20/dist/css/tabler.min.css">
   <link rel="stylesheet" href="assets/css/custom.css">
+  <link rel="icon" href="../img/favicon.ico">
 </head>
 <body class="antialiased">
 <div class="wrapper">
@@ -51,7 +52,7 @@
         <div class="col-sm-6 col-lg-3">
           <div class="card card-stat-accent">
             <div class="card-body">
-              <div class="subheader">Active AOs</div>
+              <div class="subheader" title="Distinct AO sites with at least one workout in 2026 (excludes #downrange and Shield Lock)">Active AOs</div>
               <div class="h1 mb-0" id="stat-total-aos">—</div>
             </div>
           </div>
@@ -59,7 +60,7 @@
         <div class="col-sm-6 col-lg-3">
           <div class="card card-stat-accent">
             <div class="card-body">
-              <div class="subheader">Overall Avg Attendance</div>
+              <div class="subheader" title="Average of each AO's per-session PAX count">Overall Avg Attendance</div>
               <div class="h1 mb-0" id="stat-avg-attendance">—</div>
             </div>
           </div>
@@ -67,7 +68,7 @@
         <div class="col-sm-6 col-lg-3">
           <div class="card card-stat-accent">
             <div class="card-body">
-              <div class="subheader">Total Unique Qs</div>
+              <div class="subheader" title="Sum of unique Q leaders across all AOs in 2026">Total Unique Qs</div>
               <div class="h1 mb-0" id="stat-total-qs">—</div>
             </div>
           </div>
@@ -75,7 +76,7 @@
         <div class="col-sm-6 col-lg-3">
           <div class="card card-stat-accent">
             <div class="card-body">
-              <div class="subheader">Total FNGs</div>
+              <div class="subheader" title="Total first-time attendees across all AOs in 2026">Total FNGs</div>
               <div class="h1 mb-0" id="stat-total-fngs">—</div>
             </div>
           </div>

--- a/static/stats/assets/css/custom.css
+++ b/static/stats/assets/css/custom.css
@@ -686,3 +686,8 @@ th[data-sort].desc::after { content: ' ↓'; opacity: 1; color: var(--green); }
 #leaderboard-heatmap        { min-height: 300px; }
 .lb-dot.filled-nq { background: #c8860a; }
 .lb-status-needsq { background: #fff3cd; color: #856404; border: 1.5px solid #ffc107; }
+
+/* ── Bench Strength coloring ── */
+.bench-high   { color: #4a5e3a; font-weight: 600; }
+.bench-mid    { color: #c8860a; }
+.bench-low    { color: #c0392b; font-weight: 600; }

--- a/static/stats/assets/css/custom.css
+++ b/static/stats/assets/css/custom.css
@@ -456,10 +456,13 @@ th[data-sort].desc::after { content: ' ↓'; opacity: 1; color: var(--green); }
 /* ── Leaderboard heatmap (Year at a Glance table) ── */
 .lb-heatmap td { text-align: center; font-size: 0.8rem; padding: 0.35rem 0.5rem; min-width: 52px; }
 .lb-heatmap th { text-align: center; font-size: 0.75rem; }
-.lb-cell-0    { color: var(--rule); }
-.lb-cell-low  { background: rgba(74,94,58,0.18); color: var(--green); border-radius: 2px; padding: 0.15rem 0.35rem; display: inline-block; min-width: 2rem; }
-.lb-cell-mid  { background: rgba(74,94,58,0.55); color: #fff; border-radius: 2px; padding: 0.15rem 0.35rem; font-weight: 600; display: inline-block; min-width: 2rem; }
-.lb-cell-done { background: var(--green); color: #fff; border-radius: 2px; padding: 0.15rem 0.35rem; font-weight: 700; display: inline-block; min-width: 2rem; }
+.lb-cell-0       { color: var(--rule); }
+.lb-cell-low     { background: rgba(0,0,0,0.10); color: var(--ink); border-radius: 2px; padding: 0.15rem 0.35rem; display: inline-block; min-width: 2rem; }
+.lb-cell-mid     { background: rgba(0,0,0,0.28); color: #fff; border-radius: 2px; padding: 0.15rem 0.35rem; font-weight: 600; display: inline-block; min-width: 2rem; }
+.lb-cell-done    { background: var(--green); color: #fff; border-radius: 2px; padding: 0.15rem 0.35rem; font-weight: 700; display: inline-block; min-width: 2rem; }
+.lb-cell-low-q   { background: rgba(74,94,58,0.22); color: var(--green); border-radius: 2px; padding: 0.15rem 0.35rem; display: inline-block; min-width: 2rem; }
+.lb-cell-mid-q   { background: rgba(74,94,58,0.60); color: #fff; border-radius: 2px; padding: 0.15rem 0.35rem; font-weight: 600; display: inline-block; min-width: 2rem; }
+.lb-cell-done-nq { background: rgba(0,0,0,0.45); color: #fff; border-radius: 2px; padding: 0.15rem 0.35rem; font-weight: 700; display: inline-block; min-width: 2rem; }
 
 /* ── #112 KPI month progress bar ── */
 .lb-month-bar-track {

--- a/static/stats/assets/js/ao.js
+++ b/static/stats/assets/js/ao.js
@@ -1,39 +1,97 @@
 // AO Stats page logic
-// Source: AO Stats tab, header at row index 2
-// Key columns: Site, Total Attendees, Avg/Meeting, FNGs, Unique Qs,
-//   Bench Strength, Active Core PAX, Most Frequent Q, Weeks in Range
-// Core PAX: cross-referenced from PAX tab via Favorite AO column
+// Computed from Raw/Master attendance tab (header at row 0)
+// Key columns from raw: Date, Name, Site, Role
+// All aggregation is performed client-side from the raw CSV.
 
 (async function () {
+  const EXCLUDED_SITES = ['#downrange', 'Shield Lock'];
+  const CORE_PAX_THRESHOLD = 0.70;
+  const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
+  const now = new Date();
+  const cutoff26w = new Date(now - 26 * MS_PER_WEEK);
+  const cutoff3w  = new Date(now - 3  * MS_PER_WEEK);
+
   let allRows = [];
   let filteredRows = [];
-  let coreByAO = {};   // { aoSiteName: ['PAX1', 'PAX2', ...] }
+  let allRawRows = [];
   let attendanceChart = null;
   let fngsByAoChart = null;
   let weeklyChart = null;
 
-  let rawRows = [];
-
   try {
-    const [aoCsv, paxCsv] = await Promise.all([
-      f3FetchCSV('ao'),
-      f3FetchCSV('pax'),
-    ]);
+    const rawCsv = await f3FetchCSV('raw');
+    allRawRows = f3ParseCSV(rawCsv, 0)
+      .filter(r => r['Name'] && r['Name'].trim() && r['Date'].startsWith('2026-'));
 
-    allRows = f3ParseCSV(aoCsv, 2);
-    allRows = allRows.filter(r => r['Site'] && r['Site'].trim() !== '');
+    // Build per-AO aggregation from raw rows
+    const aoMap = {};
+    allRawRows.forEach(r => {
+      const site = r['Site'].trim();
+      if (EXCLUDED_SITES.includes(site)) return;
+      if (!aoMap[site]) aoMap[site] = {
+        dates: new Set(),
+        weeks: new Set(),
+        names: new Set(),
+        qNames: new Set(),
+        qCounts: {},
+        fngCount: 0,
+        totalPosts: 0,
+        w26dates: new Set(),
+        w26byName: {},
+      };
+      const ao = aoMap[site];
+      ao.dates.add(r['Date']);
+      ao.weeks.add(weekMonday(r['Date']));
+      ao.names.add(r['Name'].trim());
+      ao.totalPosts++;
+      if (r['Role'] === 'Q') {
+        const n = r['Name'].trim();
+        ao.qNames.add(n);
+        ao.qCounts[n] = (ao.qCounts[n] || 0) + 1;
+      }
+      if (r['Role'] === 'FNG') ao.fngCount++;
 
-    // Build core PAX map: group PAX by their Favorite AO
-    const paxRows = f3ParseCSV(paxCsv, 2).filter(r => {
-      const s = (r['Site'] || '').trim();
-      return s !== '' && isNaN(Number(s));
+      // 26-week window for Core PAX
+      const d = new Date(r['Date'] + 'T00:00:00');
+      if (d >= cutoff26w) {
+        ao.w26dates.add(r['Date']);
+        const n = r['Name'].trim();
+        ao.w26byName[n] = (ao.w26byName[n] || 0) + 1;
+      }
     });
-    paxRows.forEach(r => {
-      const ao = (r['Favorite AO'] || '').trim();
-      if (!ao || ao === '#downrange') return;
-      if (!coreByAO[ao]) coreByAO[ao] = [];
-      coreByAO[ao].push(r['Site'].trim());
+
+    // Build allRows array
+    allRows = Object.entries(aoMap).map(([site, ao]) => {
+      const distinctSessions = ao.dates.size;
+      const avgPerMeeting = distinctSessions > 0 ? ao.totalPosts / distinctSessions : 0;
+      const benchStrength = ao.names.size > 0 ? ao.qNames.size / ao.names.size * 100 : 0;
+
+      const entries = Object.entries(ao.qCounts);
+      const mostFreqQ = entries.length
+        ? entries.reduce((a, b) => b[1] > a[1] ? b : a)[0]
+        : '—';
+
+      const ao26sessions = ao.w26dates.size;
+      const corePax = ao26sessions > 0
+        ? Object.entries(ao.w26byName)
+            .filter(([, cnt]) => cnt / ao26sessions >= CORE_PAX_THRESHOLD)
+            .map(([name]) => name)
+            .sort()
+        : [];
+
+      return {
+        'Site': site,
+        'Total Attendees': ao.totalPosts,
+        'Weeks in Range': ao.weeks.size,
+        'Avg/Meeting': avgPerMeeting,
+        'FNGs': ao.fngCount,
+        'Unique Qs': ao.qNames.size,
+        'Bench Strength': benchStrength,
+        'Most Frequent Q': mostFreqQ,
+        '_corePax': corePax,
+      };
     });
+
   } catch (e) {
     f3ShowError('ao-table-container', e.message);
     f3ShowError('ao-cards-grid', e.message);
@@ -43,15 +101,6 @@
   filteredRows = [...allRows];
   renderAll();
 
-  // Fetch the heavy raw CSV after above-fold content is already rendered
-  f3FetchCSV('raw').then(rawCsv => {
-    rawRows = f3ParseCSV(rawCsv, 0).filter(r =>
-      r['Date'] && r['Date'].match(/^\d{4}-\d{2}-\d{2}$/) &&
-      r['Site'] && r['Site'].trim() !== '' && r['Site'].trim() !== '#downrange'
-    );
-    renderWeeklyAttendance(rawRows);
-  }).catch(() => {});
-
   // Set up sortable — must call AFTER table is first rendered
   // Uses getter so it always sorts the current filteredRows
   function setupSortable() {
@@ -60,7 +109,7 @@
 
   function renderAll() {
     renderStatCards(filteredRows);
-    renderWeeklyAttendance(rawRows);
+    renderWeeklyAttendance(allRawRows);
     renderAttendanceChart(filteredRows);
     renderFngsByAoChart(filteredRows);
     renderAOCards(filteredRows);
@@ -185,9 +234,10 @@
     grid.innerHTML = rows.map(r => {
       const avg = parseFloat(r['Avg/Meeting']) || 0;
       const bench = parseFloat(r['Bench Strength']);
-      const benchDisplay = isNaN(bench) ? (r['Bench Strength'] || '—') : bench.toFixed(1) + '%';
+      const benchCls = bench >= 40 ? 'bench-high' : bench >= 20 ? 'bench-mid' : 'bench-low';
+      const benchHtml = isNaN(bench) ? '—' : `<span class="${benchCls}">${bench.toFixed(1)}%</span>`;
       const topQ = r['Most Frequent Q'] || '—';
-      const corePax = coreByAO[r['Site'].trim()] || [];
+      const corePax = r['_corePax'] || [];
       const coreHtml = corePax.length
         ? corePax.map(name => f3Esc(name)).join(', ')
         : '<em style="color:var(--muted);">None listed</em>';
@@ -208,7 +258,7 @@
               </div>
               <div class="col-6">
                 <div class="text-muted small">Bench Strength</div>
-                <div class="fw-bold">${benchDisplay}</div>
+                <div class="fw-bold">${benchHtml}</div>
               </div>
               <div class="col-6">
                 <div class="text-muted small">Top Q</div>
@@ -229,14 +279,14 @@
         <table class="table table-vcenter table-hover card-table" id="ao-full-table">
           <thead>
             <tr>
-              <th data-sort="Site">Site</th>
-              <th data-sort="Total Attendees">Total Posts</th>
-              <th data-sort="Weeks in Range">Weeks</th>
-              <th data-sort="Avg/Meeting">Avg/Meeting</th>
-              <th data-sort="FNGs">FNGs</th>
-              <th data-sort="Unique Qs">Unique Qs</th>
-              <th data-sort="Bench Strength">Bench Strength</th>
-              <th>Core Names</th>
+              <th data-sort="Site" title="AO name">Site</th>
+              <th data-sort="Total Attendees" title="Total individual posts at this AO in 2026">Total Posts</th>
+              <th data-sort="Weeks in Range" title="Number of distinct weeks this AO has run in 2026">Weeks</th>
+              <th data-sort="Avg/Meeting" title="Average PAX count per session (Total Posts ÷ Distinct Sessions)">Avg/Meeting</th>
+              <th data-sort="FNGs" title="Number of first-time attendees at this AO in 2026">FNGs</th>
+              <th data-sort="Unique Qs" title="Number of distinct PAX who have led a workout (Q) at this AO in 2026">Unique Qs</th>
+              <th data-sort="Bench Strength" title="% of attendees who have Q'd at least once — higher means more Q depth (green ≥40%, amber 20–39%, red &lt;20%)">Bench Strength</th>
+              <th title="PAX who attend ≥70% of sessions in the last 26 weeks">Core Names</th>
             </tr>
           </thead>
           <tbody id="ao-table-body"></tbody>
@@ -250,7 +300,9 @@
     if (!body) return;
     body.innerHTML = rows.map(r => {
       const bench = parseFloat(r['Bench Strength']);
-      const benchDisplay = isNaN(bench) ? (r['Bench Strength'] || '—') : bench.toFixed(1) + '%';
+      const benchCls = !isNaN(bench) ? (bench >= 40 ? 'bench-high' : bench >= 20 ? 'bench-mid' : 'bench-low') : '';
+      const benchDisplay = isNaN(bench) ? '—' : `<span class="${benchCls}">${bench.toFixed(1)}%</span>`;
+      const coreNames = (r['_corePax'] || []).join(', ') || '—';
       return `<tr>
         <td>${f3Esc(r['Site'])}</td>
         <td>${r['Total Attendees'] || '—'}</td>
@@ -259,7 +311,7 @@
         <td>${r['FNGs'] || '0'}</td>
         <td>${r['Unique Qs'] || '—'}</td>
         <td>${benchDisplay}</td>
-        <td class="text-muted small">${f3Esc(r['Core Names'] && r['Core Names'] !== '-' ? r['Core Names'] : '—')}</td>
+        <td class="text-muted small">${f3Esc(coreNames)}</td>
       </tr>`;
     }).join('');
   }

--- a/static/stats/assets/js/ao.js
+++ b/static/stats/assets/js/ao.js
@@ -5,6 +5,16 @@
 
 (async function () {
   const EXCLUDED_SITES = ['#downrange', 'Shield Lock'];
+  const AO_DISPLAY_EXCLUSIONS = [
+    'Convergence',
+    'Raiders of the Locked Park',
+    'Who let the dogs out (possible new AO?) Hunter street',
+    'Shieldlock',
+    'Ruck the Hall',
+    'Q-Source Q',
+    'Floppy Ruck',
+  ];
+  const AO_EXCLUSIONS_LC = new Set(AO_DISPLAY_EXCLUSIONS.map(s => s.toLowerCase()));
   const CORE_PAX_THRESHOLD = 0.70;
   const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
   const now = new Date();
@@ -27,6 +37,7 @@
     allRawRows.forEach(r => {
       const site = r['Site'].trim();
       if (EXCLUDED_SITES.includes(site)) return;
+      if (AO_EXCLUSIONS_LC.has(site.toLowerCase())) return;
       if (!aoMap[site]) aoMap[site] = {
         dates: new Set(),
         weeks: new Set(),

--- a/static/stats/assets/js/ao.js
+++ b/static/stats/assets/js/ao.js
@@ -19,7 +19,6 @@
   const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
   const now = new Date();
   const cutoff26w = new Date(now - 26 * MS_PER_WEEK);
-  const cutoff3w  = new Date(now - 3  * MS_PER_WEEK);
 
   let allRows = [];
   let filteredRows = [];

--- a/static/stats/assets/js/ao.js
+++ b/static/stats/assets/js/ao.js
@@ -23,7 +23,6 @@
     allRawRows = f3ParseCSV(rawCsv, 0)
       .filter(r => r['Name'] && r['Name'].trim() && r['Date'].startsWith('2026-'));
 
-    // Build per-AO aggregation from raw rows
     const aoMap = {};
     allRawRows.forEach(r => {
       const site = r['Site'].trim();
@@ -51,7 +50,6 @@
       }
       if (r['Role'] === 'FNG') ao.fngCount++;
 
-      // 26-week window for Core PAX
       const d = new Date(r['Date'] + 'T00:00:00');
       if (d >= cutoff26w) {
         ao.w26dates.add(r['Date']);
@@ -60,7 +58,6 @@
       }
     });
 
-    // Build allRows array
     allRows = Object.entries(aoMap).map(([site, ao]) => {
       const distinctSessions = ao.dates.size;
       const avgPerMeeting = distinctSessions > 0 ? ao.totalPosts / distinctSessions : 0;

--- a/static/stats/assets/js/ao.js
+++ b/static/stats/assets/js/ao.js
@@ -265,15 +265,15 @@
                 <div class="fw-bold">${r['Total Attendees'] || '—'}</div>
               </div>
               <div class="col-6">
-                <div class="text-muted small">Bench Strength</div>
+                <div class="text-muted small" title="% of attendees who have Q'd at least once — higher means more Q depth (green ≥40%, amber 20–39%, red &lt;20%)">Bench Strength</div>
                 <div class="fw-bold">${benchHtml}</div>
               </div>
               <div class="col-6">
-                <div class="text-muted small">Top Q</div>
+                <div class="text-muted small" title="PAX who most frequently led workouts at this AO in 2026">Top Q</div>
                 <div class="fw-bold">${f3Esc(topQ)}</div>
               </div>
             </div>
-            <div class="text-muted small mb-1">Core PAX (${corePax.length})</div>
+            <div class="text-muted small mb-1" title="PAX who attend ≥70% of sessions in the last 26 weeks">Core PAX (${corePax.length})</div>
             <div class="ao-core-list">${coreHtml}</div>
           </div>
         </div>`;

--- a/static/stats/assets/js/fng.js
+++ b/static/stats/assets/js/fng.js
@@ -1,16 +1,73 @@
 // FNG Stats page logic
-// Source: FNG Stats tab, header at row index 0
-// Status values: '👻 Ghosted', '⏳ Pending (Grace Period)', '🌱 Developing (Returned)'
+// Source: Raw/Master tab — computes FNG data from attendance records
+// Status values: '👻 Ghosted', '⏳ Pending (Grace Period)', '🌱 Developing (Returned)', '🛡️ Regular'
+
+const now = new Date();
+
+function isoToMdy(isoDate) {
+  const [y, m, d] = isoDate.split('-');
+  return `${parseInt(m)}/${parseInt(d)}/${y}`;
+}
+
+function fngStatus(totalPosts, firstPostDate) {
+  const daysSince = Math.floor((now - firstPostDate) / 86400000);
+  if (totalPosts >= 10)                        return '🛡️ Regular';
+  if (totalPosts > 1)                          return '🌱 Developing (Returned)';
+  if (totalPosts === 1 && daysSince > 14)      return '👻 Ghosted';
+  if (totalPosts === 1 && daysSince <= 14)     return '⏳ Pending (Grace Period)';
+  return 'Checking Data...';
+}
 
 (async function () {
   let allRows = [];
   let filteredRows = [];
 
   try {
-    const csv = await f3FetchCSV('fng');
-    allRows = f3ParseCSV(csv, 0);
-    // Remove rows where FNG Name is blank (trailing sheet rows or date-header col)
-    allRows = allRows.filter(r => r['FNG Name'] && r['FNG Name'].trim() !== '');
+    const rawCsv = await f3FetchCSV('raw');
+    const allRawRows = f3ParseCSV(rawCsv, 0)
+      .filter(r => r['Name'] && r['Name'].trim() && r['Date'].startsWith('2026-'));
+
+    // Group all raw rows by Name
+    const byName = {};
+    allRawRows.forEach(r => {
+      const name = r['Name'].trim();
+      if (!byName[name]) byName[name] = [];
+      byName[name].push(r);
+    });
+
+    // Build per-FNG rows: only names that have at least one Role='FNG' record
+    Object.entries(byName).forEach(([name, records]) => {
+      const fngRecord = records.find(r => r['Role'] === 'FNG');
+      if (!fngRecord) return;
+
+      // Sort all records by date ascending
+      const sorted = records.slice().sort((a, b) => a['Date'].localeCompare(b['Date']));
+      const firstPostIso = fngRecord['Date'];
+      const firstPostDate = f3ParseLocalDate(firstPostIso);
+      const firstPost = isoToMdy(firstPostIso);
+
+      const secondRecord = sorted.length >= 2 ? sorted[1] : null;
+      const secondPost = secondRecord ? isoToMdy(secondRecord['Date']) : '';
+      let daysTo2nd = '';
+      if (secondRecord) {
+        const secondDate = f3ParseLocalDate(secondRecord['Date']);
+        daysTo2nd = Math.floor((secondDate - firstPostDate) / 86400000);
+      }
+
+      const totalPosts = sorted.length;
+      const homeAO = fngRecord['Site'];
+      const status = fngStatus(totalPosts, firstPostDate);
+
+      allRows.push({
+        'FNG Name': name,
+        'First Post': firstPost,
+        '2nd Post': secondPost,
+        'Days to 2nd post': daysTo2nd,
+        'Total Posts to date': totalPosts,
+        'Home AO': homeAO,
+        'Status': status,
+      });
+    });
   } catch (e) {
     f3ShowError('fng-table-container', e.message);
     f3ShowError('chart-fng-status', e.message);
@@ -69,18 +126,21 @@
     document.getElementById('stat-ghosted').textContent = ghosted;
     const pending = rows.filter(r => r['Status'] && r['Status'].includes('Pending')).length;
     document.getElementById('stat-pending').textContent = pending;
+    const regular = rows.filter(r => r['Status'] && r['Status'].includes('Regular')).length;
+    document.getElementById('stat-regular').textContent = regular;
   }
 
   function renderStatusDonut(rows) {
+    const regular    = rows.filter(r => r['Status'] && r['Status'].includes('Regular')).length;
     const developing = rows.filter(r => r['Status'] && r['Status'].includes('Developing')).length;
     const ghosted    = rows.filter(r => r['Status'] && r['Status'].includes('Ghosted')).length;
     const pending    = rows.filter(r => r['Status'] && r['Status'].includes('Pending')).length;
 
     const options = {
       chart: { type: 'donut', height: 320, fontFamily: "'Open Sans', sans-serif", background: 'transparent' },
-      series: [developing, ghosted, pending],
-      labels: ['Developing', 'Ghosted', 'Pending'],
-      colors: ['#4a5e3a', '#8a7a60', '#c8a840'],
+      series: [regular, developing, ghosted, pending],
+      labels: ['Regular', 'Developing', 'Ghosted', 'Pending'],
+      colors: ['#4a5e3a', '#7a9a68', '#8a7a60', '#c8a840'],
       grid: { borderColor: '#c8bfa8' },
       legend: { position: 'bottom' },
       tooltip: { theme: 'light', style: { fontFamily: "'Open Sans', sans-serif" } },
@@ -168,13 +228,13 @@
         <table class="table table-vcenter table-hover card-table" id="fng-full-table">
           <thead>
             <tr>
-              <th data-sort="FNG Name">FNG Name</th>
-              <th data-sort="First Post">First Post</th>
-              <th data-sort="2nd Post">2nd Post</th>
-              <th data-sort="Days to 2nd post">Days to Return</th>
-              <th data-sort="Total Posts to date">Total Posts</th>
-              <th data-sort="Status">Status</th>
-              <th data-sort="Home AO">Home AO</th>
+              <th data-sort="FNG Name" title="PAX F3 handle">FNG Name</th>
+              <th data-sort="First Post" title="Date of first attendance at Peak City">First Post</th>
+              <th data-sort="2nd Post" title="Date of second attendance">2nd Post</th>
+              <th data-sort="Days to 2nd post" title="Days between first and second post — lower is better retention signal">Days to Return</th>
+              <th data-sort="Total Posts to date" title="Total posts in 2026">Total Posts</th>
+              <th data-sort="Status" title="Retention status based on post count and days since first post">Status</th>
+              <th data-sort="Home AO" title="The AO where this PAX first attended">Home AO</th>
             </tr>
           </thead>
           <tbody id="fng-table-body"></tbody>

--- a/static/stats/assets/js/fng.js
+++ b/static/stats/assets/js/fng.js
@@ -80,34 +80,6 @@
   renderAll();
   f3MakeSortable('fng-full-table', () => filteredRows, renderTableBody);
 
-  document.getElementById('filter-apply').addEventListener('click', () => {
-    const from = document.getElementById('filter-from').value;
-    const to = document.getElementById('filter-to').value;
-    filteredRows = f3FilterByDateRange(allRows, 'First Post', from, to);
-    updateFilterLabel(from, to);
-    renderAll();
-  });
-
-  document.getElementById('filter-clear').addEventListener('click', () => {
-    document.getElementById('filter-from').value = '';
-    document.getElementById('filter-to').value = '';
-    filteredRows = [...allRows];
-    updateFilterLabel('', '');
-    renderAll();
-  });
-
-  function updateFilterLabel(from, to) {
-    const lbl = document.getElementById('filter-result-label');
-    if (!lbl) return;
-    if (!from && !to) {
-      lbl.style.display = 'none';
-      lbl.textContent = '';
-    } else {
-      lbl.style.display = 'block';
-      lbl.textContent = `Showing ${filteredRows.length} of ${allRows.length} FNGs`;
-    }
-  }
-
   function renderAll() {
     renderStatCards(filteredRows);
     renderStatusDonut(filteredRows);
@@ -120,8 +92,6 @@
     document.getElementById('stat-total-fngs').textContent = rows.length;
     const retained = rows.filter(r => r['Status'] && r['Status'].includes('Developing')).length;
     document.getElementById('stat-retained').textContent = retained;
-    const ghosted = rows.filter(r => r['Status'] && r['Status'].includes('Ghosted')).length;
-    document.getElementById('stat-ghosted').textContent = ghosted;
     const pending = rows.filter(r => r['Status'] && r['Status'].includes('Pending')).length;
     document.getElementById('stat-pending').textContent = pending;
     const regular = rows.filter(r => r['Status'] && r['Status'].includes('Regular')).length;

--- a/static/stats/assets/js/fng.js
+++ b/static/stats/assets/js/fng.js
@@ -2,25 +2,26 @@
 // Source: Raw/Master tab — computes FNG data from attendance records
 // Status values: '👻 Ghosted', '⏳ Pending (Grace Period)', '🌱 Developing (Returned)', '🛡️ Regular'
 
-const now = new Date();
-
-function isoToMdy(isoDate) {
-  const [y, m, d] = isoDate.split('-');
-  return `${parseInt(m)}/${parseInt(d)}/${y}`;
-}
-
-function fngStatus(totalPosts, firstPostDate) {
-  const daysSince = Math.floor((now - firstPostDate) / 86400000);
-  if (totalPosts >= 10)                        return '🛡️ Regular';
-  if (totalPosts > 1)                          return '🌱 Developing (Returned)';
-  if (totalPosts === 1 && daysSince > 14)      return '👻 Ghosted';
-  if (totalPosts === 1 && daysSince <= 14)     return '⏳ Pending (Grace Period)';
-  return 'Checking Data...';
-}
-
 (async function () {
   let allRows = [];
   let filteredRows = [];
+
+  const now = new Date();
+  const EXCLUDED_SITES = ['#downrange', 'Shield Lock'];
+
+  function isoToMdy(isoDate) {
+    const [y, m, d] = isoDate.split('-');
+    return `${parseInt(m)}/${parseInt(d)}/${y}`;
+  }
+
+  function fngStatus(totalPosts, firstPostDate) {
+    const daysSince = Math.floor((now - firstPostDate) / 86400000);
+    if (totalPosts >= 10)                        return '🛡️ Regular';
+    if (totalPosts > 1)                          return '🌱 Developing (Returned)';
+    if (totalPosts === 1 && daysSince > 14)      return '👻 Ghosted';
+    if (totalPosts === 1 && daysSince <= 14)     return '⏳ Pending (Grace Period)';
+    return 'Checking Data...';
+  }
 
   try {
     const rawCsv = await f3FetchCSV('raw');
@@ -51,7 +52,7 @@ function fngStatus(totalPosts, firstPostDate) {
         daysTo2nd = Math.floor((secondDate - firstPostDate) / 86400000);
       }
 
-      const totalPosts = sorted.length;
+      const totalPosts = byName[name].filter(r => !EXCLUDED_SITES.includes((r['Site'] || '').trim())).length;
       const homeAO = fngRecord['Site'];
       const status = fngStatus(totalPosts, firstPostDate);
 

--- a/static/stats/assets/js/fng.js
+++ b/static/stats/assets/js/fng.js
@@ -27,7 +27,6 @@ function fngStatus(totalPosts, firstPostDate) {
     const allRawRows = f3ParseCSV(rawCsv, 0)
       .filter(r => r['Name'] && r['Name'].trim() && r['Date'].startsWith('2026-'));
 
-    // Group all raw rows by Name
     const byName = {};
     allRawRows.forEach(r => {
       const name = r['Name'].trim();
@@ -35,12 +34,10 @@ function fngStatus(totalPosts, firstPostDate) {
       byName[name].push(r);
     });
 
-    // Build per-FNG rows: only names that have at least one Role='FNG' record
     Object.entries(byName).forEach(([name, records]) => {
       const fngRecord = records.find(r => r['Role'] === 'FNG');
       if (!fngRecord) return;
 
-      // Sort all records by date ascending
       const sorted = records.slice().sort((a, b) => a['Date'].localeCompare(b['Date']));
       const firstPostIso = fngRecord['Date'];
       const firstPostDate = f3ParseLocalDate(firstPostIso);

--- a/static/stats/assets/js/fng.js
+++ b/static/stats/assets/js/fng.js
@@ -36,7 +36,7 @@
     });
 
     Object.entries(byName).forEach(([name, records]) => {
-      const fngRecord = records.find(r => r['Role'] === 'FNG');
+      const fngRecord = records.find(r => r['Role'] === 'FNG' && !EXCLUDED_SITES.includes((r['Site'] || '').trim()));
       if (!fngRecord) return;
 
       const sorted = records.slice().sort((a, b) => a['Date'].localeCompare(b['Date']));

--- a/static/stats/assets/js/leaderboard.js
+++ b/static/stats/assets/js/leaderboard.js
@@ -17,6 +17,7 @@ const POST_GOAL = 12;
   let showRegularsOnly = true;
   let barChart = null;
   let activeMonths = [];
+  let streakMonths = [];
   let currentMonth = '';
 
   try {
@@ -50,8 +51,14 @@ const POST_GOAL = 12;
 
     // Determine active months
     const todayMonthIdx = new Date().getMonth(); // 0=Jan … 11=Dec
+    const todayDate = now.getDate();
     currentMonth = MONTHS[todayMonthIdx] ?? MONTHS[0];
     activeMonths = MONTHS.filter((_, i) => i <= todayMonthIdx);
+    // For streak counting: use previous month until the 14th to avoid showing
+    // everyone as "0 streak" during the first two weeks of a new month.
+    streakMonths = (todayDate < 14 && activeMonths.length > 1)
+      ? activeMonths.slice(0, -1)
+      : activeMonths;
 
     function dateToMonthLabel(dateStr) {
       if (!dateStr || !dateStr.startsWith('2026-')) return null;
@@ -77,7 +84,7 @@ const POST_GOAL = 12;
       MONTHS.forEach(m => { row[m] = agg.posts[m] ? String(agg.posts[m]) : ''; });
       row['_qs'] = agg.qs;
 
-      const completedMonths = activeMonths.map(m =>
+      const completedMonths = streakMonths.map(m =>
         (parseInt(row[m]) || 0) >= POST_GOAL && (agg.qs[m] || 0) >= 1
       );
       let streak = 0;
@@ -154,6 +161,16 @@ const POST_GOAL = 12;
       return parseInt(s.split('/')[0]) > 0;
     }).length;
     document.getElementById('stat-streakers').textContent = streakers;
+
+    const streakersLabel = document.getElementById('stat-streakers-label');
+    if (streakersLabel) {
+      if (streakMonths.length < activeMonths.length && streakMonths.length > 0) {
+        const prevMonthShort = streakMonths[streakMonths.length - 1].replace(' 2026', '');
+        streakersLabel.textContent = `Active Streakers (thru ${prevMonthShort})`;
+      } else {
+        streakersLabel.textContent = 'Active Streakers';
+      }
+    }
   }
 
   function renderBarChart(monthlyTotals) {
@@ -208,7 +225,10 @@ const POST_GOAL = 12;
         else if (hasData && val >= POST_GOAL)     cls += ' filled-nq';
         else if (hasData && val > 0)              cls += ' partial';
         const ringStyle = isCurrent ? 'outline:2px solid var(--green);outline-offset:2px;' : '';
-        const label = hasData ? `${m.replace(' 2026','')}: ${val} posts` : `${m.replace(' 2026','')}: —`;
+        const qCount = r['_qs']?.[m] || 0;
+        const label = hasData
+          ? `${m.replace(' 2026','')}: ${val} post${val !== 1 ? 's' : ''} · ${qCount} Q${qCount !== 1 ? 's' : ''}`
+          : `${m.replace(' 2026','')}: —`;
         return `<span class="${cls}" title="${label}" style="${ringStyle}"></span>`;
       }).join('');
 
@@ -257,12 +277,13 @@ const POST_GOAL = 12;
     const container = document.getElementById('leaderboard-table');
     if (!container) return;
 
-    function cellClass(raw) {
+    function cellClass(raw, qCount) {
       const n = parseInt(raw) || 0;
+      const hasQ = (qCount || 0) >= 1;
       if (n === 0)          return 'lb-cell-0';
-      if (n < 6)            return 'lb-cell-low';
-      if (n < POST_GOAL)    return 'lb-cell-mid';
-      return 'lb-cell-done';
+      if (n < 6)            return hasQ ? 'lb-cell-low-q'  : 'lb-cell-low';
+      if (n < POST_GOAL)    return hasQ ? 'lb-cell-mid-q'  : 'lb-cell-mid';
+      return hasQ ? 'lb-cell-done' : 'lb-cell-done-nq';
     }
 
     const thead = `<thead><tr>
@@ -274,7 +295,8 @@ const POST_GOAL = 12;
     const tbody = filteredRows.map(r => {
       const cells = activeMonths.map(m => {
         const val = (r[m] || '').trim();
-        const cls = cellClass(val);
+        const qCount = r['_qs']?.[m] || 0;
+        const cls = cellClass(val, qCount);
         return `<td><span class="${cls}">${f3Esc(val || '—')}</span></td>`;
       }).join('');
       return `<tr>

--- a/static/stats/assets/js/pax.js
+++ b/static/stats/assets/js/pax.js
@@ -119,6 +119,7 @@
   let donutChart = null;
   let favDayChart = null;
   let trajectoryChart = null;
+  let qpChart = null;
 
   renderAll();
   f3MakeSortable('pax-full-table', () => filteredRows, renderTableBody);
@@ -283,30 +284,32 @@
       .filter(r => {
         const avgWk = parseFloat(r['Avg/Week']);
         const totalQ = parseInt(r['Total Q']) || 0;
-        return !isNaN(avgWk) && avgWk < 1.0 && avgWk > 0 && totalQ >= 1;
+        return !isNaN(avgWk) && avgWk > 1.0 && totalQ >= 1;
       })
       .sort((a, b) => parseFloat(b['Q/P Ratio']) - parseFloat(a['Q/P Ratio']))
       .slice(0, 10);
 
-    const container = document.getElementById('chart-qp-ratio');
-    if (!top10.length) { container.innerHTML = '<p class="text-muted p-3">No data</p>'; return; }
+    const options = {
+      chart: { type: 'bar', height: Math.max(200, top10.length * 32 + 60), toolbar: { show: false }, fontFamily: "'Open Sans', sans-serif", background: 'transparent' },
+      series: [{ name: 'Q/P %', data: top10.map(r => parseFloat((parseFloat(r['Q/P Ratio']) * 100).toFixed(1))) }],
+      xaxis: { categories: top10.map(r => r['Site']), labels: { formatter: v => `${v}%` } },
+      colors: ['#4a5e3a'],
+      grid: { borderColor: '#c8bfa8' },
+      plotOptions: { bar: { horizontal: true, barHeight: '65%' } },
+      dataLabels: { enabled: true, style: { fontSize: '11px' }, formatter: v => `${v}%` },
+      yaxis: { labels: { style: { fontSize: '11px' } } },
+      tooltip: { theme: 'light', style: { fontFamily: "'Open Sans', sans-serif" }, y: { formatter: v => `${v}%` } },
+      noData: { text: 'No qualifying PAX', align: 'center', verticalAlign: 'middle', style: { fontFamily: "'Open Sans', sans-serif", color: '#8a7a60' } },
+    };
 
-    const maxRatio = parseFloat(top10[0]['Q/P Ratio']);
-    container.innerHTML = `<div class="qp-leader-list">${
-      top10.map((r, i) => {
-        const ratio = parseFloat(r['Q/P Ratio']);
-        const pct = (ratio * 100).toFixed(1);
-        const barW = Math.round((ratio / maxRatio) * 100);
-        return `<div class="qp-leader-row">
-        <div class="qp-leader-meta">
-          <span class="qp-rank">#${i + 1}</span>
-          <span class="qp-name">${f3Esc(r['Site'])}</span>
-          <span class="qp-pct">${pct}%</span>
-        </div>
-        <div class="qp-bar-track"><div class="qp-bar-fill" style="width:${barW}%"></div></div>
-      </div>`;
-      }).join('')
-    }</div>`;
+    if (qpChart) {
+      qpChart.updateOptions(options);
+    } else {
+      f3LazyChart('chart-qp-ratio', () => {
+        qpChart = new ApexCharts(document.getElementById('chart-qp-ratio'), options);
+        qpChart.render();
+      });
+    }
   }
 
   function renderTable(rows) {

--- a/static/stats/assets/js/pax.js
+++ b/static/stats/assets/js/pax.js
@@ -17,7 +17,6 @@
     const allRawRows = f3ParseCSV(rawCsv, 0)
       .filter(r => r['Name'] && r['Name'].trim() && r['Date'].startsWith('2026-'));
 
-    // Step 2: PC Regular computation (rolling window, excl. EXCLUDED_SITES)
     const pcWindowCounts = {};
     allRawRows.forEach(r => {
       const site = (r['Site'] || '').trim();
@@ -34,7 +33,6 @@
       pcRegMap[name] = c.w26 >= 26 || c.w3 >= 3;
     });
 
-    // Step 3: Per-PAX aggregation — group records by Name
     const paxMap = {};
     allRawRows.forEach(r => {
       const name = r['Name'].trim();
@@ -42,35 +40,29 @@
       paxMap[name].records.push(r);
     });
 
-    // Step 4: Build allRows with computed metrics
     allRows = Object.entries(paxMap).map(([name, agg]) => {
       const paxRecords = agg.records;
       const totalPost = paxRecords.length;
       const totalQ = paxRecords.filter(r => r['Role'] === 'Q').length;
 
-      // Min/max dates
       const dates = paxRecords.map(r => r['Date']).sort();
       const minDate = dates[0];
       const maxDate = dates[dates.length - 1];
 
-      // Last Seen — store as integer (days ago)
       const lastSeenDate = f3ParseLocalDate(maxDate);
       const lastSeenDays = lastSeenDate
         ? Math.floor((now - lastSeenDate) / 86400000)
         : null;
 
-      // Last 3wk count
       const last3wkCount = paxRecords.filter(r => {
         const d = f3ParseLocalDate(r['Date']);
         return d && d >= cutoff3w;
       }).length;
 
-      // Avg/Week
       const firstDate = f3ParseLocalDate(minDate);
       const daysSinceFirstPost = firstDate ? (now - firstDate) / 86400000 : 0;
       const avgWeek = totalPost / (Math.max(1, daysSinceFirstPost) / 7);
 
-      // Favorite AO (MODE of Site, excl. EXCLUDED_SITES)
       const siteCounts = {};
       paxRecords.forEach(r => {
         const s = (r['Site'] || '').trim();
@@ -80,7 +72,6 @@
         ? Object.entries(siteCounts).reduce((a, b) => b[1] > a[1] ? b : a)[0]
         : '—';
 
-      // Favorite Day of the week (MODE)
       const dayCounts = {};
       paxRecords.forEach(r => {
         const day = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'][new Date(r['Date'] + 'T00:00:00').getDay()];
@@ -264,7 +255,6 @@
   }
 
   function renderTrajectoryChart(rows) {
-    // Computed values: '🔥 Heating Up', '❄️ Cooling Off', '-' (no change)
     const TRAJ_MAP = {
       '🔥 Heating Up':  { label: '🔥 Heating Up',     color: '#c8a840' },
       '❄️ Cooling Off': { label: '❄️ Cooling Off',    color: '#8a9aaf' },
@@ -291,7 +281,6 @@
     else { f3LazyChart('chart-trajectory', () => { trajectoryChart = new ApexCharts(document.getElementById('chart-trajectory'), options); trajectoryChart.render(); }); }
   }
 
-  // Quality over Quantity: PAX averaging < 1 post/week with the highest Q/P ratio
   function renderQpRatioChart(rows) {
     const top10 = [...rows]
       .filter(r => {
@@ -346,7 +335,6 @@
         </table>
       </div>`;
     renderTableBody(rows);
-    // Re-attach sortable after table rebuild
     f3MakeSortable('pax-full-table', () => filteredRows, renderTableBody);
   }
 

--- a/static/stats/assets/js/pax.js
+++ b/static/stats/assets/js/pax.js
@@ -1,19 +1,123 @@
 // PAX Stats page logic
-// Source: PAX Stats tab, header at row index 2
-// Note: the "Site" column contains PAX F3 names/handles (confusingly named)
-// Filter: skip rows where Site is blank or pure numeric (summary rows)
+// Source: Raw/Master attendance tab (single fetch, aggregated client-side)
+// Note: the "Site" field in allRows holds the PAX name (matches old PAX tab convention)
 
 (async function () {
+  const EXCLUDED_SITES = ['#downrange', 'Shield Lock'];
+  const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
+  const now = new Date();
+  const cutoff26w = new Date(now - 26 * MS_PER_WEEK);
+  const cutoff3w  = new Date(now - 3  * MS_PER_WEEK);
+
   let allRows = [];
   let filteredRows = [];
 
   try {
-    const csv = await f3FetchCSV('pax');
-    allRows = f3ParseCSV(csv, 2);
-    allRows = allRows.filter(r => {
+    const rawCsv = await f3FetchCSV('raw');
+    const allRawRows = f3ParseCSV(rawCsv, 0)
+      .filter(r => r['Name'] && r['Name'].trim() && r['Date'].startsWith('2026-'));
+
+    // Step 2: PC Regular computation (rolling window, excl. EXCLUDED_SITES)
+    const pcWindowCounts = {};
+    allRawRows.forEach(r => {
       const site = (r['Site'] || '').trim();
-      return site !== '' && isNaN(Number(site));
+      if (EXCLUDED_SITES.includes(site)) return;
+      const d = f3ParseLocalDate(r['Date']);
+      if (!d || d < cutoff26w) return;
+      const name = r['Name'].trim();
+      if (!pcWindowCounts[name]) pcWindowCounts[name] = { w26: 0, w3: 0 };
+      pcWindowCounts[name].w26++;
+      if (d >= cutoff3w) pcWindowCounts[name].w3++;
     });
+    const pcRegMap = {};
+    Object.entries(pcWindowCounts).forEach(([name, c]) => {
+      pcRegMap[name] = c.w26 >= 26 || c.w3 >= 3;
+    });
+
+    // Step 3: Per-PAX aggregation — group records by Name
+    const paxMap = {};
+    allRawRows.forEach(r => {
+      const name = r['Name'].trim();
+      if (!paxMap[name]) paxMap[name] = { records: [] };
+      paxMap[name].records.push(r);
+    });
+
+    // Step 4: Build allRows with computed metrics
+    allRows = Object.entries(paxMap).map(([name, agg]) => {
+      const paxRecords = agg.records;
+      const totalPost = paxRecords.length;
+      const totalQ = paxRecords.filter(r => r['Role'] === 'Q').length;
+
+      // Min/max dates
+      const dates = paxRecords.map(r => r['Date']).sort();
+      const minDate = dates[0];
+      const maxDate = dates[dates.length - 1];
+
+      // Last Seen — store as integer (days ago)
+      const lastSeenDate = f3ParseLocalDate(maxDate);
+      const lastSeenDays = lastSeenDate
+        ? Math.floor((now - lastSeenDate) / 86400000)
+        : null;
+
+      // Last 3wk count
+      const last3wkCount = paxRecords.filter(r => {
+        const d = f3ParseLocalDate(r['Date']);
+        return d && d >= cutoff3w;
+      }).length;
+
+      // Avg/Week
+      const firstDate = f3ParseLocalDate(minDate);
+      const daysSinceFirstPost = firstDate ? (now - firstDate) / 86400000 : 0;
+      const avgWeek = totalPost / (Math.max(1, daysSinceFirstPost) / 7);
+
+      // Favorite AO (MODE of Site, excl. EXCLUDED_SITES)
+      const siteCounts = {};
+      paxRecords.forEach(r => {
+        const s = (r['Site'] || '').trim();
+        if (s && !EXCLUDED_SITES.includes(s)) siteCounts[s] = (siteCounts[s] || 0) + 1;
+      });
+      const favAO = Object.entries(siteCounts).length
+        ? Object.entries(siteCounts).reduce((a, b) => b[1] > a[1] ? b : a)[0]
+        : '—';
+
+      // Favorite Day of the week (MODE)
+      const dayCounts = {};
+      paxRecords.forEach(r => {
+        const day = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'][new Date(r['Date'] + 'T00:00:00').getDay()];
+        dayCounts[day] = (dayCounts[day] || 0) + 1;
+      });
+      const favDay = Object.entries(dayCounts).length
+        ? Object.entries(dayCounts).reduce((a, b) => b[1] > a[1] ? b : a)[0]
+        : '—';
+
+      // Trajectory (second pass over allRawRows for 26w window)
+      const last26wPosts = allRawRows.filter(r2 =>
+        r2['Name'].trim() === name &&
+        f3ParseLocalDate(r2['Date']) >= cutoff26w
+      ).length;
+      const avg3w  = last3wkCount / 3;
+      const avg26w = last26wPosts / 26;
+      const trajectory =
+        last3wkCount >= 2 && avg3w > avg26w ? '🔥 Heating Up' :
+        avg3w < avg26w                       ? '❄️ Cooling Off' :
+        '-';
+
+      return {
+        'Site': name,
+        'PC Regular?': pcRegMap[name] ? 'TRUE' : 'FALSE',
+        'Total Post': totalPost,
+        'Total Q': totalQ,
+        'Q/P Ratio': totalPost > 0 ? totalQ / totalPost : 0,
+        'Last Seen': lastSeenDays,
+        'Last 3 wk': last3wkCount,
+        'Avg/Week': avgWeek,
+        'Avg/Last 3 Weeks': last3wkCount / 3,
+        'Favorite AO': favAO,
+        'Favorite Day of the week': favDay,
+        'Trajectory': trajectory,
+      };
+    }).sort((a, b) => a['Site'].localeCompare(b['Site']));
+
   } catch (e) {
     f3ShowError('pax-table-container', e.message);
     f3ShowError('chart-top-pax', e.message);
@@ -27,7 +131,6 @@
   let donutChart = null;
   let favDayChart = null;
   let trajectoryChart = null;
-  let qpRatioChart = null;
 
   renderAll();
   f3MakeSortable('pax-full-table', () => filteredRows, renderTableBody);
@@ -161,7 +264,7 @@
   }
 
   function renderTrajectoryChart(rows) {
-    // Actual sheet values: '🔥 Heating Up', '❄️ Cooling Off', '-' (no change)
+    // Computed values: '🔥 Heating Up', '❄️ Cooling Off', '-' (no change)
     const TRAJ_MAP = {
       '🔥 Heating Up':  { label: '🔥 Heating Up',     color: '#c8a840' },
       '❄️ Cooling Off': { label: '❄️ Cooling Off',    color: '#8a9aaf' },
@@ -188,15 +291,16 @@
     else { f3LazyChart('chart-trajectory', () => { trajectoryChart = new ApexCharts(document.getElementById('chart-trajectory'), options); trajectoryChart.render(); }); }
   }
 
+  // Quality over Quantity: PAX averaging < 1 post/week with the highest Q/P ratio
   function renderQpRatioChart(rows) {
     const top10 = [...rows]
       .filter(r => {
-        const v = parseFloat(r['Q/P Ratio']);
-        const posts = parseInt(r['Total Post']) || 0;
-        return !isNaN(v) && v > 0 && posts >= 5;
+        const avgWk = parseFloat(r['Avg/Week']);
+        const totalQ = parseInt(r['Total Q']) || 0;
+        return !isNaN(avgWk) && avgWk < 1.0 && avgWk > 0 && totalQ >= 1;
       })
       .sort((a, b) => parseFloat(b['Q/P Ratio']) - parseFloat(a['Q/P Ratio']))
-      .slice(0, 5);
+      .slice(0, 10);
 
     const container = document.getElementById('chart-qp-ratio');
     if (!top10.length) { container.innerHTML = '<p class="text-muted p-3">No data</p>'; return; }
@@ -208,13 +312,13 @@
         const pct = (ratio * 100).toFixed(1);
         const barW = Math.round((ratio / maxRatio) * 100);
         return `<div class="qp-leader-row">
-          <div class="qp-leader-meta">
-            <span class="qp-rank">#${i + 1}</span>
-            <span class="qp-name">${f3Esc(r['Site'])}</span>
-            <span class="qp-pct">${pct}%</span>
-          </div>
-          <div class="qp-bar-track"><div class="qp-bar-fill" style="width:${barW}%"></div></div>
-        </div>`;
+        <div class="qp-leader-meta">
+          <span class="qp-rank">#${i + 1}</span>
+          <span class="qp-name">${f3Esc(r['Site'])}</span>
+          <span class="qp-pct">${pct}%</span>
+        </div>
+        <div class="qp-bar-track"><div class="qp-bar-fill" style="width:${barW}%"></div></div>
+      </div>`;
       }).join('')
     }</div>`;
   }
@@ -226,16 +330,16 @@
         <table class="table table-vcenter table-hover card-table" id="pax-full-table">
           <thead>
             <tr>
-              <th data-sort="Site">PAX</th>
-              <th data-sort="Last Seen">Last Seen</th>
-              <th data-sort="Total Post">Posts</th>
-              <th data-sort="Total Q">Qs</th>
-              <th data-sort="Q/P Ratio">Q/P Ratio</th>
-              <th data-sort="Avg/Week">Avg/Wk</th>
-              <th data-sort="Avg/Last 3 Weeks">Avg/3Wk</th>
-              <th data-sort="Last 3 wk">Last 3 Wks</th>
-              <th data-sort="Trajectory">Trajectory</th>
-              <th data-sort="Favorite AO">Fav AO</th>
+              <th data-sort="Site" title="PAX F3 handle">PAX</th>
+              <th data-sort="Last Seen" title="Days since last post — lower means more recently active">Last Seen</th>
+              <th data-sort="Total Post" title="Total posts in 2026">Posts</th>
+              <th data-sort="Total Q" title="Total workouts led (Q) in 2026">Qs</th>
+              <th data-sort="Q/P Ratio" title="Fraction of posts where this PAX led the workout (Q ÷ Total Posts)">Q/P Ratio</th>
+              <th data-sort="Avg/Week" title="Average posts per week since first 2026 post">Avg/Wk</th>
+              <th data-sort="Avg/Last 3 Weeks" title="Average posts per week over the last 3 weeks">Avg/3Wk</th>
+              <th data-sort="Last 3 wk" title="Number of posts in the last 3 weeks">Last 3 Wks</th>
+              <th data-sort="Trajectory" title="Trend: compares avg posts per week in last 3 weeks vs last 26 weeks (requires ≥2 posts in last 3 weeks for Heating Up)">Trajectory</th>
+              <th data-sort="Favorite AO" title="Most frequently attended AO in 2026 (excludes #downrange and Shield Lock)">Fav AO</th>
             </tr>
           </thead>
           <tbody id="pax-table-body"></tbody>
@@ -255,9 +359,10 @@
       const avg3Wk = parseFloat(r['Avg/Last 3 Weeks']);
       const traj = (r['Trajectory'] || '').trim();
       const trajLabel = { '🔥 Heating Up': 'Heating Up', '❄️ Cooling Off': 'Cooling Off', '-': '—' }[traj] || traj || '—';
+      const lastSeen = r['Last Seen'];
       return `<tr>
         <td><strong>${f3Esc(r['Site'])}</strong></td>
-        <td>${f3Esc(r['Last Seen'] || '—')}</td>
+        <td>${lastSeen != null ? `${lastSeen} days ago` : '—'}</td>
         <td>${r['Total Post'] || '0'}</td>
         <td>${r['Total Q'] || '0'}</td>
         <td>${isNaN(qpRatio) ? '—' : (qpRatio * 100).toFixed(1) + '%'}</td>

--- a/static/stats/assets/js/pax.js
+++ b/static/stats/assets/js/pax.js
@@ -81,11 +81,8 @@
         ? Object.entries(dayCounts).reduce((a, b) => b[1] > a[1] ? b : a)[0]
         : '—';
 
-      // Trajectory (second pass over allRawRows for 26w window)
-      const last26wPosts = allRawRows.filter(r2 =>
-        r2['Name'].trim() === name &&
-        f3ParseLocalDate(r2['Date']) >= cutoff26w
-      ).length;
+      // Trajectory (O(1) lookup — pcWindowCounts already computed 26w posts excluding EXCLUDED_SITES)
+      const last26wPosts = (pcWindowCounts[name] || { w26: 0 }).w26;
       const avg3w  = last3wkCount / 3;
       const avg26w = last26wPosts / 26;
       const trajectory =

--- a/static/stats/assets/js/pax.js
+++ b/static/stats/assets/js/pax.js
@@ -88,7 +88,7 @@
       const trajectory =
         last3wkCount >= 2 && avg3w > avg26w ? '🔥 Heating Up' :
         avg3w < avg26w                       ? '❄️ Cooling Off' :
-        '-';
+        '➡️ Holding Steady';
 
       return {
         'Site': name,
@@ -254,14 +254,14 @@
 
   function renderTrajectoryChart(rows) {
     const TRAJ_MAP = {
-      '🔥 Heating Up':  { label: '🔥 Heating Up',     color: '#c8a840' },
-      '❄️ Cooling Off': { label: '❄️ Cooling Off',    color: '#8a9aaf' },
-      '-':              { label: '➡️ Holding Steady',  color: '#c8bfa8' },
+      '🔥 Heating Up':      { label: '🔥 Heating Up',      color: '#c8a840' },
+      '❄️ Cooling Off':     { label: '❄️ Cooling Off',     color: '#8a9aaf' },
+      '➡️ Holding Steady': { label: '➡️ Holding Steady', color: '#c8bfa8' },
     };
     const counts = {};
     rows.forEach(r => {
-      const t = (r['Trajectory'] || '-').trim();
-      const key = TRAJ_MAP[t] ? t : '-';
+      const t = (r['Trajectory'] || '➡️ Holding Steady').trim();
+      const key = TRAJ_MAP[t] ? t : '➡️ Holding Steady';
       counts[key] = (counts[key] || 0) + 1;
     });
     const keys = Object.keys(TRAJ_MAP).filter(k => counts[k] > 0);
@@ -345,8 +345,7 @@
       const qpRatio = parseFloat(r['Q/P Ratio']);
       const avgWk = parseFloat(r['Avg/Week']);
       const avg3Wk = parseFloat(r['Avg/Last 3 Weeks']);
-      const traj = (r['Trajectory'] || '').trim();
-      const trajLabel = { '🔥 Heating Up': 'Heating Up', '❄️ Cooling Off': 'Cooling Off', '-': '—' }[traj] || traj || '—';
+      const traj = (r['Trajectory'] || '➡️ Holding Steady').trim();
       const lastSeen = r['Last Seen'];
       return `<tr>
         <td><strong>${f3Esc(r['Site'])}</strong></td>
@@ -357,7 +356,7 @@
         <td>${isNaN(avgWk) ? '—' : avgWk.toFixed(1)}</td>
         <td>${isNaN(avg3Wk) ? '—' : avg3Wk.toFixed(1)}</td>
         <td>${r['Last 3 wk'] || '0'}</td>
-        <td>${f3Esc(trajLabel)}</td>
+        <td>${f3Esc(traj)}</td>
         <td class="text-muted">${f3Esc(r['Favorite AO'] || '—')}</td>
       </tr>`;
     }).join('');

--- a/static/stats/fng.html
+++ b/static/stats/fng.html
@@ -8,6 +8,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@700;800;900&family=Lora:wght@400;600;700&family=Open+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
   <noscript><link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@700;800;900&family=Lora:wght@400;600;700&family=Open+Sans:wght@400;500;600;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.0.0-beta20/dist/css/tabler.min.css">
+  <link rel="icon" href="../img/favicon.ico">
   <link rel="stylesheet" href="assets/css/custom.css">
 </head>
 <body class="antialiased">
@@ -62,7 +63,7 @@
         <div class="col-sm-6 col-lg-3">
           <div class="card card-stat-accent">
             <div class="card-body">
-              <div class="subheader">Total FNGs</div>
+              <div class="subheader" title="Total first-time attendees in 2026 (within current date filter)">Total FNGs</div>
               <div class="h1 mb-0" id="stat-total-fngs">—</div>
             </div>
           </div>
@@ -70,7 +71,7 @@
         <div class="col-sm-6 col-lg-3">
           <div class="card card-stat-accent">
             <div class="card-body">
-              <div class="subheader">Developing / Retained</div>
+              <div class="subheader" title="FNGs who returned for a 2nd post but have fewer than 10 total posts">Developing / Retained</div>
               <div class="h1 mb-0" id="stat-retained">—</div>
             </div>
           </div>
@@ -78,7 +79,7 @@
         <div class="col-sm-6 col-lg-3">
           <div class="card card-stat-accent">
             <div class="card-body">
-              <div class="subheader">Ghosted</div>
+              <div class="subheader" title="FNGs with only 1 post and more than 14 days since their first post">Ghosted</div>
               <div class="h1 mb-0" id="stat-ghosted">—</div>
             </div>
           </div>
@@ -86,8 +87,16 @@
         <div class="col-sm-6 col-lg-3">
           <div class="card card-stat-accent">
             <div class="card-body">
-              <div class="subheader">Pending</div>
+              <div class="subheader" title="FNGs with only 1 post and 14 days or fewer since their first post — still in grace period">Pending</div>
               <div class="h1 mb-0" id="stat-pending">—</div>
+            </div>
+          </div>
+        </div>
+        <div class="col-sm-6 col-lg-3">
+          <div class="card card-stat-accent">
+            <div class="card-body">
+              <div class="subheader" title="FNGs who have posted 10+ times — they stuck around and became regulars">Graduated Regular</div>
+              <div class="h1 mb-0" id="stat-regular">—</div>
             </div>
           </div>
         </div>

--- a/static/stats/fng.html
+++ b/static/stats/fng.html
@@ -43,18 +43,7 @@
         <div class="row align-items-center">
           <div class="col">
             <h2 class="page-title">FNG Stats</h2>
-            <p class="text-muted">Tracking how we're doing bringing in new guys and keeping them</p>
-          </div>
-          <div class="col-auto">
-            <div class="input-group">
-              <label for="filter-from" class="input-group-text">First Post From</label>
-              <input type="date" id="filter-from" class="form-control form-control-sm">
-              <label for="filter-to" class="input-group-text">To</label>
-              <input type="date" id="filter-to" class="form-control form-control-sm">
-              <button class="btn btn-sm" id="filter-apply">Apply</button>
-              <button class="btn btn-sm" id="filter-clear" style="background:transparent;border-color:var(--rule);color:var(--muted);border-radius:0;font-size:0.68rem;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;">Clear</button>
-            </div>
-            <div class="filter-result-label" id="filter-result-label" style="display:none"></div>
+            <p class="text-muted">Tracking how we're doing bringing in new guys and keeping them &mdash; all data from Jan 1, 2026</p>
           </div>
         </div>
       </div>
@@ -73,14 +62,6 @@
             <div class="card-body">
               <div class="subheader" title="FNGs who returned for a 2nd post but have fewer than 10 total posts">Developing / Retained</div>
               <div class="h1 mb-0" id="stat-retained">—</div>
-            </div>
-          </div>
-        </div>
-        <div class="col-sm-6 col-lg-3">
-          <div class="card card-stat-accent">
-            <div class="card-body">
-              <div class="subheader" title="FNGs with only 1 post and more than 14 days since their first post">Ghosted</div>
-              <div class="h1 mb-0" id="stat-ghosted">—</div>
             </div>
           </div>
         </div>

--- a/static/stats/index.html
+++ b/static/stats/index.html
@@ -55,12 +55,8 @@
           <div class="lbl" title="Distinct AO sites with at least one 2026 workout (excludes #downrange and Shield Lock)">Active AOs</div>
         </div>
         <div class="stat-cell">
-          <div class="num accent" id="stat-fngs">—</div>
-          <div class="lbl" title="First-time attendees in 2026">FNGs This Year</div>
-        </div>
-        <div class="stat-cell">
           <div class="num accent" id="stat-fng-retention">—</div>
-          <div class="lbl" title="% of 2026 FNGs who reached 10+ total posts (🛡️ Regular status)">FNG → Regular</div>
+          <div class="lbl" title="Of 2026 FNGs, how many reached 10+ posts (🛡️ Regular status) — shown as count and retention %">FNG → Regular</div>
         </div>
       </div>
 
@@ -129,7 +125,7 @@
 
   function setAll(val) {
     ['hero-posts','stat-pax','landing-pax-stat','stat-aos','landing-ao-stat',
-     'stat-fngs','landing-fng-stat','landing-lb-stat','stat-fng-retention'].forEach(id => setEl(id, val));
+     'landing-fng-stat','landing-lb-stat','stat-fng-retention'].forEach(id => setEl(id, val));
   }
 
   try {
@@ -162,7 +158,6 @@
     setEl('landing-pax-stat', totalPax);
     setEl('stat-aos', activeAOs);
     setEl('landing-ao-stat', activeAOs);
-    setEl('stat-fngs', totalFngs);
     setEl('landing-fng-stat', totalFngs);
     setEl('landing-lb-stat', totalPax);
     setEl('stat-fng-retention', retentionText);

--- a/static/stats/index.html
+++ b/static/stats/index.html
@@ -9,6 +9,7 @@
   <noscript><link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@700;800;900&family=Lora:wght@400;600;700&family=Open+Sans:wght@400;500;600;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.0.0-beta20/dist/css/tabler.min.css">
   <link rel="stylesheet" href="assets/css/custom.css">
+  <link rel="icon" href="../img/favicon.ico">
 </head>
 <body class="antialiased">
 <div class="wrapper">
@@ -41,21 +42,25 @@
       <div class="headline-section">
         <div class="edition-label">All-time region total</div>
         <div class="hero-number" id="hero-posts">—</div>
-        <div class="hero-label">Posts &amp; Counting ↑</div>
+        <div class="hero-label" title="Total workout posts recorded in 2026">Posts &amp; Counting ↑</div>
       </div>
 
       <div class="stat-row">
         <div class="stat-cell">
           <div class="num" id="stat-pax">—</div>
-          <div class="lbl">Total PAX</div>
+          <div class="lbl" title="Distinct PAX who have posted at least once in 2026">Total PAX</div>
         </div>
         <div class="stat-cell">
           <div class="num" id="stat-aos">—</div>
-          <div class="lbl">Active AOs</div>
+          <div class="lbl" title="Distinct AO sites with at least one 2026 workout (excludes #downrange and Shield Lock)">Active AOs</div>
         </div>
         <div class="stat-cell">
           <div class="num accent" id="stat-fngs">—</div>
-          <div class="lbl">FNGs This Year</div>
+          <div class="lbl" title="First-time attendees in 2026">FNGs This Year</div>
+        </div>
+        <div class="stat-cell">
+          <div class="num accent" id="stat-fng-retention">—</div>
+          <div class="lbl" title="% of 2026 FNGs who reached 10+ total posts (🛡️ Regular status)">FNG → Regular</div>
         </div>
       </div>
 
@@ -115,51 +120,55 @@
 <script src="assets/js/data.js"></script>
 <script>
 (async function() {
-  // Hero: total posts across all PAX
+  const EXCLUDED_SITES = ['#downrange', 'Shield Lock'];
+
+  function setEl(id, val) {
+    const el = document.getElementById(id);
+    if (el) el.textContent = val;
+  }
+
+  function setAll(val) {
+    ['hero-posts','stat-pax','landing-pax-stat','stat-aos','landing-ao-stat',
+     'stat-fngs','landing-fng-stat','landing-lb-stat','stat-fng-retention'].forEach(id => setEl(id, val));
+  }
+
   try {
-    const csv = await f3FetchCSV('pax');
-    const rows = f3ParseCSV(csv, 2).filter(r => {
-      const s = (r['Site'] || '').trim();
-      return s !== '' && isNaN(Number(s));
+    const rawCsv = await f3FetchCSV('raw');
+    const allRawRows = f3ParseCSV(rawCsv, 0)
+      .filter(r => r['Name'] && r['Name'].trim() && r['Date'].startsWith('2026-'));
+
+    const totalPosts = allRawRows.length;
+    const paxSet = new Set(allRawRows.map(r => r['Name'].trim()));
+    const totalPax = paxSet.size;
+    const activeAOs = new Set(
+      allRawRows.filter(r => !EXCLUDED_SITES.includes((r['Site'] || '').trim())).map(r => r['Site'].trim())
+    ).size;
+    const totalFngs = allRawRows.filter(r => r['Role'] === 'FNG').length;
+
+    // FNG → Regular: FNGs whose total 2026 post count >= 10
+    const fngNames = new Set(allRawRows.filter(r => r['Role'] === 'FNG').map(r => r['Name'].trim()));
+    const postsByName = {};
+    allRawRows.forEach(r => {
+      const n = r['Name'].trim();
+      postsByName[n] = (postsByName[n] || 0) + 1;
     });
-    const totalPosts = rows.reduce((sum, r) => sum + (parseInt(r['Total Post']) || 0), 0);
-    document.getElementById('hero-posts').textContent = totalPosts.toLocaleString();
-    document.getElementById('stat-pax').textContent = rows.length;
-    document.getElementById('landing-pax-stat').textContent = rows.length;
-  } catch {
-    document.getElementById('hero-posts').textContent = '—';
-    document.getElementById('stat-pax').textContent = '—';
-    document.getElementById('landing-pax-stat').textContent = '—';
-  }
+    const regularCount = [...fngNames].filter(n => (postsByName[n] || 0) >= 10).length;
+    const fngCount = fngNames.size;
+    const retentionPct = fngCount > 0 ? Math.round((regularCount / fngCount) * 100) : 0;
+    const retentionText = `${regularCount} of ${fngCount} (${retentionPct}%)`;
 
-  // AOs
-  try {
-    const csv = await f3FetchCSV('ao');
-    const rows = f3ParseCSV(csv, 2).filter(r => r['Site'] && r['Site'].trim());
-    document.getElementById('stat-aos').textContent = rows.length;
-    document.getElementById('landing-ao-stat').textContent = rows.length;
-  } catch {
-    document.getElementById('stat-aos').textContent = '—';
-    document.getElementById('landing-ao-stat').textContent = '—';
+    setEl('hero-posts', totalPosts.toLocaleString());
+    setEl('stat-pax', totalPax);
+    setEl('landing-pax-stat', totalPax);
+    setEl('stat-aos', activeAOs);
+    setEl('landing-ao-stat', activeAOs);
+    setEl('stat-fngs', totalFngs);
+    setEl('landing-fng-stat', totalFngs);
+    setEl('landing-lb-stat', totalPax);
+    setEl('stat-fng-retention', retentionText);
+  } catch (e) {
+    setAll('—');
   }
-
-  // FNGs
-  try {
-    const csv = await f3FetchCSV('fng');
-    const rows = f3ParseCSV(csv, 0).filter(r => r['FNG Name'] && r['FNG Name'].trim());
-    document.getElementById('stat-fngs').textContent = rows.length;
-    document.getElementById('landing-fng-stat').textContent = rows.length;
-  } catch {
-    document.getElementById('stat-fngs').textContent = '—';
-    document.getElementById('landing-fng-stat').textContent = '—';
-  }
-
-  // Leaderboard
-  try {
-    const csv = await f3FetchCSV('leaderboard');
-    const rows = f3ParseCSV(csv, 1).filter(r => r['PAX'] && r['PAX'].trim());
-    document.getElementById('landing-lb-stat').textContent = rows.length;
-  } catch { document.getElementById('landing-lb-stat').textContent = '—'; }
 })();
 </script>
 </body>

--- a/static/stats/leaderboard.html
+++ b/static/stats/leaderboard.html
@@ -55,7 +55,7 @@
 
       <div class="row row-cards mt-3">
         <div class="col-sm-4">
-          <div class="card card-stat-accent">
+          <div class="card card-stat-accent h-100">
             <div class="card-body">
               <div class="subheader">Total in Crew (Year)</div>
               <div class="h1 mb-0" id="stat-total-crew">—</div>
@@ -63,7 +63,7 @@
           </div>
         </div>
         <div class="col-sm-4">
-          <div class="card card-stat-accent">
+          <div class="card card-stat-accent h-100">
             <div class="card-body">
               <div class="subheader">Current Month Completions</div>
               <div class="h1 mb-0" id="stat-current-month">—</div>
@@ -75,9 +75,9 @@
           </div>
         </div>
         <div class="col-sm-4">
-          <div class="card card-stat-accent">
+          <div class="card card-stat-accent h-100">
             <div class="card-body">
-              <div class="subheader">Active Streakers</div>
+              <div class="subheader" id="stat-streakers-label">Active Streakers</div>
               <div class="h1 mb-0" id="stat-streakers">—</div>
             </div>
           </div>
@@ -93,7 +93,6 @@
         <span class="flag-text">Who's In The Crew</span>
         <span class="flag-rule"></span>
       </div>
-      <p style="font-family:'Open Sans',sans-serif;font-size:0.6rem;color:var(--muted);font-style:italic;margin:0.4rem 0 0.5rem;">* Current month post count only appears once you've completed a Q that month.</p>
       <div id="leaderboard-heatmap">
         <div class="d-flex justify-content-center p-4">
           <div class="spinner-border" role="status">
@@ -106,9 +105,10 @@
         <div class="card-header d-flex align-items-center justify-content-between">
           <h3 class="card-title">Year at a Glance</h3>
           <span style="font-family:'Open Sans',sans-serif;font-size:0.6rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--muted);display:flex;align-items:center;gap:8px;">
-            <span style="display:inline-flex;align-items:center;gap:4px;"><span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:rgba(74,94,58,0.18);flex-shrink:0;"></span>1–5</span>
-            <span style="display:inline-flex;align-items:center;gap:4px;"><span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:rgba(74,94,58,0.55);flex-shrink:0;"></span>6–11</span>
-            <span style="display:inline-flex;align-items:center;gap:4px;"><span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:#4a5e3a;flex-shrink:0;"></span>12+</span>
+            <span style="display:inline-flex;align-items:center;gap:4px;"><span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:rgba(0,0,0,0.10);border:1px solid rgba(0,0,0,0.18);flex-shrink:0;"></span>1–5</span>
+            <span style="display:inline-flex;align-items:center;gap:4px;"><span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:rgba(0,0,0,0.28);flex-shrink:0;"></span>6–11</span>
+            <span style="display:inline-flex;align-items:center;gap:4px;"><span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:rgba(0,0,0,0.45);flex-shrink:0;"></span>12+ no Q</span>
+            <span style="display:inline-flex;align-items:center;gap:4px;"><span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:#4a5e3a;flex-shrink:0;"></span>12+ ✓</span>
           </span>
         </div>
         <div class="card-body p-0" id="leaderboard-table">

--- a/static/stats/pax.html
+++ b/static/stats/pax.html
@@ -7,6 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@700;800;900&family=Lora:wght@400;600;700&family=Open+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
   <noscript><link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@700;800;900&family=Lora:wght@400;600;700&family=Open+Sans:wght@400;500;600;700&display=swap" rel="stylesheet"></noscript>
+  <link rel="icon" href="../img/favicon.ico">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.0.0-beta20/dist/css/tabler.min.css">
   <link rel="stylesheet" href="assets/css/custom.css">
 </head>
@@ -57,7 +58,7 @@
         <div class="col-sm-6 col-lg-3">
           <div class="card card-stat-accent">
             <div class="card-body">
-              <div class="subheader">Total PAX</div>
+              <div class="subheader" title="Number of PAX in current filter (PC Regulars or All PAX)">Total PAX</div>
               <div class="h1 mb-0" id="stat-total-pax">—</div>
             </div>
           </div>
@@ -65,7 +66,7 @@
         <div class="col-sm-6 col-lg-3">
           <div class="card card-stat-accent">
             <div class="card-body">
-              <div class="subheader">Active Last 3 Weeks</div>
+              <div class="subheader" title="PAX who have posted at least once in the last 3 weeks">Active Last 3 Weeks</div>
               <div class="h1 mb-0" id="stat-active-3wk">—</div>
             </div>
           </div>
@@ -73,7 +74,7 @@
         <div class="col-sm-6 col-lg-3">
           <div class="card card-stat-accent">
             <div class="card-body">
-              <div class="subheader">Total Posts</div>
+              <div class="subheader" title="Sum of all posts in 2026 for the current filter">Total Posts</div>
               <div class="h1 mb-0" id="stat-total-posts">—</div>
             </div>
           </div>
@@ -81,7 +82,7 @@
         <div class="col-sm-6 col-lg-3">
           <div class="card card-stat-accent">
             <div class="card-body">
-              <div class="subheader">Total Qs</div>
+              <div class="subheader" title="Sum of all Q-led workouts in 2026 for the current filter">Total Qs</div>
               <div class="h1 mb-0" id="stat-total-qs">—</div>
             </div>
           </div>
@@ -118,7 +119,7 @@
         </div>
         <div class="col-lg-4">
           <div class="card">
-            <div class="card-header"><h3 class="card-title">Top Q Leaders</h3></div>
+            <div class="card-header"><h3 class="card-title" title="PAX averaging less than 1 post/week in 2026 with the highest Q-to-Post ratio — the guys who show up to lead">Quality over Quantity</h3></div>
             <div class="card-body" id="chart-qp-ratio"></div>
           </div>
         </div>

--- a/static/stats/pax.html
+++ b/static/stats/pax.html
@@ -119,7 +119,7 @@
         </div>
         <div class="col-lg-4">
           <div class="card">
-            <div class="card-header"><h3 class="card-title" title="PAX averaging less than 1 post/week in 2026 with the highest Q-to-Post ratio — the guys who show up to lead">Quality over Quantity</h3></div>
+            <div class="card-header"><h3 class="card-title" title="PAX averaging more than 1 post/week in 2026 with the highest Q-to-Post ratio — high-volume contributors who also lead">Quality over Quantity</h3></div>
             <div class="card-body" id="chart-qp-ratio"></div>
           </div>
         </div>

--- a/static/stats/pax.html
+++ b/static/stats/pax.html
@@ -43,7 +43,7 @@
         <div class="row align-items-center">
           <div class="col">
             <h2 class="page-title">PAX Stats</h2>
-            <p class="text-muted">Individual participation metrics</p>
+            <p class="text-muted">Individual participation metrics &mdash; all data from Jan 1, 2026</p>
           </div>
           <div class="col-auto">
             <div class="filter-toggle-group" role="group" aria-label="Filter PAX">


### PR DESCRIPTION
## Summary

- Migrates all 4 stats pages (index, fng, ao, pax) from pre-aggregated Google Sheets tabs to the single Raw/Master attendance tab — one fetch, full dataset, computed client-side
- Closes #138, #139, #141, #140, #147, #148, #150

## What's in this branch

**Raw tab migration (all pages)**
- `index.html` — single raw fetch; new FNG→Regular KPI replaces FNG count
- `fng.js` — computes all FNG metrics (status, days-to-return, retention) from raw records
- `ao.js` — adds Core PAX, Bench Strength, AO display exclusions; removes pax tab fetch
- `pax.js` — full aggregation from raw: trajectory, Q/P ratio chart (ApexCharts horizontal bar), PC Regular rolling window

**Leaderboard polish**
- **#140** Active Streakers shows previous month until the 14th so streaks built last month stay visible early in the new month; subheader updates to "Active Streakers (thru Jun)"
- **#147** PAX dot tooltips now show `"Jun: 8 posts · 2 Qs"` instead of just post count
- **#148** Year at a Glance distinguishes Q months (green shades) from post-only months (gray scale); legend updated
- **#150** Three KPI stat cards (Total in Crew / Current Month / Active Streakers) are now equal height via `h-100`

## Test plan

- [ ] `index.html` — 3 KPI cards load; FNG→Regular shows `X of Y (Z%)`
- [ ] `fng.html` — 4 stat cards (Regular/Developing/Ghosted/Pending); status column shows emoji prefixes
- [ ] `ao.html` — 23 AOs (7 excluded); Bench Strength colored; Core PAX list on cards
- [ ] `pax.html` — QoQ chart shows PAX averaging >1/wk; trajectory emoji labels; PC Regular toggle works
- [ ] `leaderboard.html` — KPI cards equal height; dot tooltips include Q count; Year at a Glance gray/green cells; Active Streakers subheader adjusts on day < 14

🤖 Generated with [Claude Code](https://claude.com/claude-code)