### PR TITLE
fix: write GCP_SA_KEY to a credentials file instead of google-github-actions/auth

### DIFF
--- a/.github/workflows/who2q-refresh.yml
+++ b/.github/workflows/who2q-refresh.yml
@@ -13,10 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -27,8 +23,20 @@ jobs:
       - name: Run unit tests
         run: python -m unittest discover -s scripts/tests -v
 
+      - name: Create BQ credentials
+        env:
+          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+        run: echo "$GCP_SA_KEY" > bq_credentials.json
+
       - name: Generate who2q.json
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: bq_credentials.json
+          GOOGLE_CLOUD_PROJECT: f3data
         run: python scripts/who2q_export.py
+
+      - name: Clean up credentials
+        if: always()
+        run: rm -f bq_credentials.json
 
       - name: Commit if changed
         run: |


### PR DESCRIPTION
## Summary
- The scheduled "Refresh Who2Q data" workflow failed on its first run: `google-github-actions/auth@v2` errored because it never received a usable `credentials_json` input (the `GCP_SA_KEY` secret didn't exist in this repo at the time).
- Aligns the credential-handling mechanism with the pattern already used in `Slack_Data_Collector/bq-import.yml`: write the secret to a JSON file via `echo`, then point `GOOGLE_APPLICATION_CREDENTIALS` at it for the step that runs the BigQuery client. Adds a cleanup step to remove the file afterward.

## Note
- This does not add the `GCP_SA_KEY` secret itself — that still needs to be added under Settings → Secrets and variables → Actions in this repo before the workflow can succeed.

## Test plan
- [ ] Add `GCP_SA_KEY` repository secret (service-account JSON with BigQuery read access to project `f3data`)
- [ ] Re-run via `workflow_dispatch` and confirm the job goes green